### PR TITLE
13 管理者ユーザー用のユーザー情報編集画面を作成する

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -97,6 +97,46 @@
   background-color: #e0e0e0; /* フォーカス時の背景色 */
 }
 
+//　フォーム関連のスタイル
+.form-title{
+  text-align: center;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  max-width: 300px; /* フォーム全体の幅を制限 */
+  margin: auto;
+}
+
+label {
+  font-weight: bold;
+  margin-top: 10px; /* ラベルと上の入力欄の間にスペースを追加 */
+  font-size: 14px;
+  color: #333;
+}
+
+input[type="text"],
+input[type="email"],
+input[type="password"] {
+  padding: 8px;
+  font-size: 14px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  margin-top: 5px; /* ラベルと入力欄の間にスペースを追加 */
+  outline: none;
+  width: 100%;
+
+}
+
+input[type="text"]:focus,
+input[type="email"]:focus,
+input[type="password"]:focus {
+  border-color: #ff6600; /* フォーカス時にオレンジ色の枠線を表示 */
+  box-shadow: 0 0 5px rgba(255, 102, 0, 0.3); /* フォーカス時に薄いオレンジ色の影を表示 */
+}
+
+
 .standard-button {
   display: inline-block; /* ブロック表示にしてボタンのようにする */
   background-color: #333; /* ボタンの背景色 */
@@ -108,6 +148,7 @@
   font-size: 16px; /* テキストサイズ */
   text-align: center; /* テキストを中央揃え */
   cursor: pointer; /* ホバー時のカーソル */
+  margin-top: 15px;
 }
 
 /* ボタンにホバーしたときのスタイル */

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,32 @@
+class Admin::UsersController < ApplicationController
+  before_action :set_user, only: [ :edit, :update ]
+  before_action :admin_user
+
+  def index
+    @users = User.all
+  end
+
+  def edit
+  end
+
+  def update
+    if @user.update(user_params)
+      redirect_to admin_users_path, notice: "ユーザー情報を更新しました"
+    else
+      render "edit"
+    end
+  end
+
+  private
+  def set_user
+    @user = User.find(params[:id])
+  end
+
+  def user_params
+    params.require(:user).permit(:name, :email, :role, :password, :password_confirmation)
+  end
+
+  def admin_user
+    redirect_to root_path unless current_user.admin?
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,5 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   has_many :result, dependent: :destroy, class_name: "Typing::Result"
+  enum role: { general: 0, admin: 1 }
 end

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,0 +1,27 @@
+<h1 class="form-title">Edit User</h1>
+<%= form_with(model: [:admin, @user], local: true) do |form| %>
+  <div>
+    <%= form.label :name %>
+    <%= form.text_field :name %>
+  </div>
+  <div>
+    <%= form.label :email %>
+    <%= form.email_field :email %>
+  </div>
+  <div>
+    <%= form.label :role %>
+    <%= form.select :role, User.roles.keys %>
+  </div>
+  <div>
+    <%= form.label :password %>
+    <%= form.text_field :password %>
+  </div>
+  <div>
+    <%= form.label :password_confirmation %>
+    <%= form.text_field :password_confirmation %>
+  </div>
+  <div>
+    <%= form.submit 'Update User', class: "standard-button" %>
+  </div>
+<% end %>
+<%= link_to 'Back', admin_users_path %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,23 @@
+<h1>Users</h1>
+<table>
+  <thead>
+  <tr>
+    <th>Name</th>
+    <th>Email</th>
+    <th>Role</th>
+    <th>Actions</th>
+  </tr>
+  </thead>
+  <tbody>
+  <% @users.each do |user| %>
+    <tr>
+      <td><%= user.name %></td>
+      <td><%= user.email %></td>
+      <td><%= user.role %></td>
+      <td>
+        <%= link_to 'Edit', edit_admin_user_path(user) %>
+      </td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,8 +23,14 @@
   <div class="navbar-item-left">
     <%= link_to "Home", "/" %>
   </div>
+
   <div class="navbar-item-left">
     <% if user_signed_in? %>
+      <% if current_user.admin? %>
+        <div class="navbar-item-left">
+          <%= link_to "User edit", admin_users_path %>
+        </div>
+      <% end %>
       Welcome, <%= current_user.name %>!
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,11 @@ Rails.application.routes.draw do
   get "typing/home"
   get "typing/start", to: "typing#start", as: "typing_start"
   get "typing/reset", to: "typing#reset", as: "typing_reset"
-  post 'typing/check_answer', to: 'typing#check_answer'
+  post "typing/check_answer", to: "typing#check_answer"
   get "typing/result"
   get "typing/play"
+
+  namespace :admin do
+    resources :users, only: [:index, :edit, :update]
+  end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_20_074058) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_10_073116) do
   create_table "typing_results", force: :cascade do |t|
     t.integer "time"
     t.integer "user_id", null: false
@@ -34,6 +34,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_20_074058) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name"
+    t.integer "role"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## チケットへのリンク

* https://github.com/SK-Study640/App_Study/issues/13

## やったこと

* 管理ユーザー向けのユーザー情報編集処理を追加
* User一覧機能
  [![Image from Gyazo](https://i.gyazo.com/d51d36bc35ed960feb9d8d173c654eba.png)](https://gyazo.com/d51d36bc35ed960feb9d8d173c654eba)
* User編集機能
  [![Image from Gyazo](https://i.gyazo.com/224c2d00918d75bf1529d29069c579c6.png)](https://gyazo.com/224c2d00918d75bf1529d29069c579c6)


## やらないこと

* なし

## できるようになること（ユーザ目線）

* 管理ユーザー：ユーザー情報の編集
* 一般ユーザー：なし

## できなくなること（ユーザ目線）

* なし

## 動作確認

* 管理ユーザーでユーザー情報を更新して反映されることを確認
* 一般ユーザーで画面にログインしようとすると、ホーム画面にリダイレクトされること